### PR TITLE
fix cakeshop-api build - pin version of babel-loader

### DIFF
--- a/cakeshop-api/src/main/webapp/package.json
+++ b/cakeshop-api/src/main/webapp/package.json
@@ -17,7 +17,7 @@
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
-    "babel-loader": "^8.0.6",
+    "babel-loader": "8.0.6",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-promise-to-bluebird": "^2.0.0",
     "react": "^16.8.6",


### PR DESCRIPTION
The build broke because a transitive dependency of `babel-loader` was updated to include object rest syntax, and babel wasn't configured to handle this. To avoid updating the entire babel configuration to support that syntax, I just pinned the version to 8.0.1, as that was the minimum version allowed per the `package.json`.  