### PR TITLE
[FIX] Non root url

### DIFF
--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/AppStartup.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/AppStartup.java
@@ -39,6 +39,9 @@ public class AppStartup implements ApplicationListener<ApplicationEvent> {
     @Value("${server.port}")
     private String SERVER_PORT;
 
+    @Value("${server.servlet.context-path}")
+    private String CONTEXT_PATH;
+
     @Value("${nodejs.binary:node}")
     String nodeJsBinaryName;
 
@@ -124,7 +127,7 @@ public class AppStartup implements ApplicationListener<ApplicationEvent> {
         System.out.println("          version:     " + AppVersion.BUILD_VERSION);
         System.out.println("          build id:    " + AppVersion.BUILD_ID);
         System.out.println("          build date:  " + AppVersion.BUILD_DATE);
-        System.out.println("          Access the Cakeshop UI at: http://localhost:" + SERVER_PORT);
+        System.out.println("          Access the Cakeshop UI at: http://localhost:" + SERVER_PORT + CONTEXT_PATH);
     }
 
     public String getDebugInfo(ServletContext servletContext) {

--- a/cakeshop-api/src/main/resources/config/application.properties
+++ b/cakeshop-api/src/main/resources/config/application.properties
@@ -32,6 +32,8 @@ spring.data.rest.basePath=/api
 
 server.port=8080
 
+server.servlet.context-path=/
+
 logging.level.root=WARN
 logging.level.io.swagger=DEBUG
 logging.level.org.springframework=INFO

--- a/cakeshop-api/src/main/webapp/js/components/NodeChooser.js
+++ b/cakeshop-api/src/main/webapp/js/components/NodeChooser.js
@@ -69,7 +69,7 @@ export default class NodeChooser extends Component {
 
     onChange = (option, action, other) => {
         if (option.value === "manage") {
-            window.location = "/manage.html";
+            window.location = "manage.html";
             return;
         }
 

--- a/cakeshop-api/src/main/webapp/js/widgets/peers-neighborhood.js
+++ b/cakeshop-api/src/main/webapp/js/widgets/peers-neighborhood.js
@@ -64,7 +64,7 @@ module.exports = function() {
 
 			_.each(hood, function(ip) {
 				var port = (window.location.port ? ':' + window.location.port : ''),
-					ep = window.location.protocol + '//' + ip + port + '/ws',
+					ep = window.location.protocol + '//' + ip + port + window.location.pathname + 'ws',
 					stomp = Stomp.over(new SockJS(ep));
 
 				stomp.debug = null;

--- a/cakeshop-api/src/main/webapp/test.html
+++ b/cakeshop-api/src/main/webapp/test.html
@@ -11,7 +11,7 @@
 //        var stompTransClient = null;
 
         function connect() {
-            var socket = new SockJS('/ws');
+            var socket = new SockJS(window.location.pathname + '/ws');
             stompClient = Stomp.over(socket);
             stompClient.connect({}, function(frame) {
                 console.log('Connected NODE: ' + frame);

--- a/cakeshop-api/src/main/webapp/test_trans.html
+++ b/cakeshop-api/src/main/webapp/test_trans.html
@@ -9,7 +9,7 @@
         var stompClient = null;
 
         function initilizeSocket() {
-            var socket = new SockJS('/ws');
+            var socket = new SockJS(window.location.pathname + 'ws');
             stompClient = Stomp.over(socket);
             stompClient.connect({}, function (frame){});
         }

--- a/cakeshop-api/src/test/resources/config/application.properties
+++ b/cakeshop-api/src/test/resources/config/application.properties
@@ -31,6 +31,8 @@ spring.data.rest.basePath=/api
 
 server.port=8080
 
+server.servlet.context-path=/
+
 logging.level.root=WARN
 logging.level.io.swagger=DEBUG
 logging.level.org.springframework=INFO

--- a/cakeshop-client-js/src/main/javascript/lib/client.js
+++ b/cakeshop-client-js/src/main/javascript/lib/client.js
@@ -54,7 +54,7 @@
     Client.connected = false;
     Client.connect = function() {
 
-        var wsUrl = '/ws';
+        var wsUrl = window.location.pathname + 'ws';
 
         var stomp = Client.stomp = Stomp.over(new SockJS(wsUrl));
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ The format of the JSON file is as follows:
 ]
 ```
 
-The rpcUrl field should be the RPC endpoint on the GoQuorum (geth) node, and the transactionManagerUrl should be the Tessera 3rd Party API endpoint. 
+The rpcUrl field should be the RPC endpoint on the GoQuorum (geth) node, and the transactionManagerUrl should be the Tessera 3rd Party API endpoint.
 
 Provide the location of the initial nodes file through application.properties or by using the `-D` flag mentioned above.
 ```sh
@@ -79,10 +79,13 @@ cakeshop.reporting.ui=http://localhost:3000
 # port to run on
 server.port=8080
 
+# context
+server.servlet.context-path=/
+
 #logging levels
 logging.level.root=WARN
 logging.level.org.springframework=INFO
 logging.level.com.jpmorgan.cakeshop=INFO
 ```
 
-See the [default config file](../cakeshop-api/src/main/resources/config/application.properties) for more. 
+See the [default config file](../cakeshop-api/src/main/resources/config/application.properties) for more.


### PR DESCRIPTION
Cakeshop is only working on the root url aka "/" but the application should work in a subdirectory, for example, "/cakeshop".
If I run the application with the option `server.servlet.context-path=/cakeshop` , the backend will run at the path "/cakeshop", but the frontend will still assume that the path is "/"

Changes made:

- Relative path for link to manage.html page
- Relative path for the web socket path
- CONTEXT_PATH variable with default value to "/"
