### PR TITLE
Update log4j to 2.17.1 for CVE-2021-44832

### DIFF
--- a/cakeshop-api/pom.xml
+++ b/cakeshop-api/pom.xml
@@ -193,7 +193,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.5</version>
+            <version>2.7</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -211,7 +211,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.19</version>
+            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/cakeshop-client-java-codegen/pom.xml
+++ b/cakeshop-client-java-codegen/pom.xml
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
 
     <dependency>

--- a/cakeshop-client-java-sample/pom.xml
+++ b/cakeshop-client-java-sample/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
     </dependency>
 
   </dependencies>

--- a/cakeshop-client-java/pom.xml
+++ b/cakeshop-client-java/pom.xml
@@ -168,7 +168,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.4</version>
+      <version>2.7</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <mockito.version>2.23.4</mockito.version>
     <nodejs.version>v10.23.1</nodejs.version>
     <npm.version>6.14.10</npm.version>
+    <log4j2.version>2.17.1</log4j2.version>
   </properties>
 
   <modules>
@@ -47,6 +48,12 @@
       <artifactId>lombok</artifactId>
       <version>1.16.22</version>
     </dependency>
+      <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-api</artifactId>
+          <version>2.17.1</version>
+      </dependency>
+
   </dependencies>
 
   <dependencyManagement>


### PR DESCRIPTION
Also bumped apache-commons versions 